### PR TITLE
Fix Google Calendar FreeBusy request formatting

### DIFF
--- a/app/services/google_calendar_sync.rb
+++ b/app/services/google_calendar_sync.rb
@@ -128,9 +128,9 @@ class GoogleCalendarSync
     return nil unless authorized?
 
     request = Google::Apis::CalendarV3::FreeBusyRequest.new(
-      time_min: start_time.iso8601,
-      time_max: end_time.iso8601,
-      time_zone: Time.zone.name,
+      time_min: start_time.to_datetime,
+      time_max: end_time.to_datetime,
+      time_zone: Time.zone.tzinfo.name,
       items: [Google::Apis::CalendarV3::FreeBusyRequestItem.new(id: CALENDAR_ID)]
     )
 

--- a/test/services/google_calendar_sync_test.rb
+++ b/test/services/google_calendar_sync_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+require "ostruct"
+
+class GoogleCalendarSyncTest < ActiveSupport::TestCase
+  test "FreeBusy request uses DateTime values and an IANA time zone" do
+    captured_request = nil
+    calendar_service = Object.new
+    calendar_service.define_singleton_method(:query_freebusy) do |request|
+      captured_request = request
+      OpenStruct.new(calendars: {})
+    end
+
+    sync = GoogleCalendarSync.allocate
+    sync.instance_variable_set(:@service, calendar_service)
+    sync.define_singleton_method(:authorized?) { true }
+
+    periods = sync.busy_periods(
+      start_time: Time.zone.parse("2026-08-20 00:00"),
+      end_time: Time.zone.parse("2026-08-20 23:59")
+    )
+
+    assert_empty periods
+    assert_instance_of DateTime, captured_request.time_min
+    assert_instance_of DateTime, captured_request.time_max
+    assert_equal "Asia/Tokyo", captured_request.time_zone
+    assert_equal "primary", captured_request.items.first.id
+  end
+end


### PR DESCRIPTION
## What changed

- Pass `DateTime` values to the Google Calendar Ruby client's FreeBusy request.
- Send the IANA time zone `Asia/Tokyo` instead of the Rails display name `Tokyo`.
- Add a regression test for the complete FreeBusy request shape.

## Why

The existing Google connection test succeeds, but public availability fails closed because the FreeBusy request uses values that do not match the Ruby client and Google API requirements.

## Rollout

Keep `GOOGLE_CALENDAR_SYNC_ENABLED=false` until this PR passes CI, is deployed, and the production booking screen is retested.