### PR TITLE
Add Google Calendar reauthorization controls

### DIFF
--- a/app/controllers/admin/google_calendar_controller.rb
+++ b/app/controllers/admin/google_calendar_controller.rb
@@ -117,12 +117,16 @@ class Admin::GoogleCalendarController < ApplicationController
   def test_connection
     begin
       sync_service = GoogleCalendarSync.new
-      events = sync_service.fetch_events(
+      busy_periods = sync_service.busy_periods(
         start_time: Time.current.beginning_of_day,
         end_time: 1.day.from_now.end_of_day
       )
-      
-      flash[:notice] = "接続成功: #{events.count}件のイベントを取得しました"
+
+      if busy_periods.nil?
+        flash[:alert] = "接続エラー: Googleカレンダーの認証が無効です。再認証してください。"
+      else
+        flash[:notice] = "接続成功: Googleカレンダーの空き状況を取得できました"
+      end
     rescue => e
       flash[:alert] = "接続エラー: #{e.message}"
     end

--- a/app/views/admin/google_calendar/index.html.erb
+++ b/app/views/admin/google_calendar/index.html.erb
@@ -144,25 +144,29 @@
           
           <% if @credentials_exist %>
             <% if @token_exist %>
-              <div class="alert alert-success">
-                <i class="fas fa-check-circle me-2"></i>認証が完了しています
-              </div>
-            <% else %>
-              <div class="mb-3">
-                <%= link_to "認証を開始", authorize_admin_google_calendar_index_path, class: "btn btn-primary", target: "_blank" %>
-              </div>
-              
-              <div class="mt-3">
-                <p class="mb-2"><strong>認証コードを入力してください：</strong></p>
-                <p class="text-muted small mb-3">
-                  Googleの認証画面で認証コードが表示されたら、そのコードをコピーして下のフォームに入力してください。
-                </p>
-                <%= form_with url: callback_admin_google_calendar_index_path, method: :get, local: true, class: "d-flex gap-2" do |f| %>
-                  <%= f.text_field :code, class: "form-control", placeholder: "認証コードを貼り付け", required: true %>
-                  <%= f.submit "認証を完了", class: "btn btn-success" %>
-                <% end %>
+              <div class="alert alert-info">
+                <i class="fas fa-info-circle me-2"></i>
+                認証情報が保存されています。接続エラーが出る場合は再認証してください。
               </div>
             <% end %>
+
+            <div class="mb-3">
+              <%= link_to(@token_exist ? "再認証を開始" : "認証を開始",
+                          authorize_admin_google_calendar_index_path,
+                          class: "btn btn-primary",
+                          target: "_blank") %>
+            </div>
+
+            <div class="mt-3">
+              <p class="mb-2"><strong>認証コードを入力してください：</strong></p>
+              <p class="text-muted small mb-3">
+                Googleの認証画面で認証コードが表示されたら、そのコードをコピーして下のフォームに入力してください。
+              </p>
+              <%= form_with url: callback_admin_google_calendar_index_path, method: :get, local: true, class: "d-flex gap-2" do |f| %>
+                <%= f.text_field :code, class: "form-control", placeholder: "認証コードを貼り付け", required: true %>
+                <%= f.submit "認証を完了", class: "btn btn-success" %>
+              <% end %>
+            </div>
           <% else %>
             <div class="alert alert-warning">
               <i class="fas fa-exclamation-triangle me-2"></i>認証情報ファイルが設定されていません


### PR DESCRIPTION
## What changed

- Always show an authorization action when Google credentials exist.
- Label it as reauthorization when a token record is already stored.
- Keep the authorization-code form visible for expired-token recovery.
- Make the connection test call FreeBusy and report an authentication error instead of a false `0 events` success.

## Why

Production logs show `invalid_grant`, but the stored token record hides the authorization controls and the old connection test swallows the failure.