### PR TITLE
Allow Google Calendar reauthorization while sync is disabled

### DIFF
--- a/GOOGLE_CALENDAR_HEROKU_DEPLOY.md
+++ b/GOOGLE_CALENDAR_HEROKU_DEPLOY.md
@@ -41,9 +41,9 @@ Herokuでは、環境変数から認証情報ファイルを動的に生成し�
 
 ```bash
 # 認証情報を環境変数として設定
-heroku config:set GOOGLE_CALENDAR_CLIENT_ID="1082079540400-ta3lg7vq2jeloc6gpl9jud02n8bn94oa.apps.googleusercontent.com"
-heroku config:set GOOGLE_CALENDAR_CLIENT_SECRET="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"
-heroku config:set GOOGLE_CALENDAR_PROJECT_ID="mobilis-ticket"
+heroku config:set GOOGLE_CALENDAR_CLIENT_ID="YOUR_CLIENT_ID"
+heroku config:set GOOGLE_CALENDAR_CLIENT_SECRET="YOUR_CLIENT_SECRET"
+heroku config:set GOOGLE_CALENDAR_PROJECT_ID="YOUR_PROJECT_ID"
 ```
 
 **注意**: アプリケーション起動時に、`config/initializers/google_calendar_credentials.rb`が環境変数から認証情報ファイルを自動生成します。

--- a/config/initializers/google_calendar_credentials.rb
+++ b/config/initializers/google_calendar_credentials.rb
@@ -4,15 +4,15 @@
 require 'json'
 
 begin
-  if Rails.env.production? && ENV['GOOGLE_CALENDAR_SYNC_ENABLED'] == 'true'
+  if Rails.env.production?
     credentials_path = Rails.root.join('config', 'google_calendar_credentials.json')
-    
+
     # 環境変数から認証情報を取得
     client_id = ENV['GOOGLE_CALENDAR_CLIENT_ID']
     client_secret = ENV['GOOGLE_CALENDAR_CLIENT_SECRET']
     project_id = ENV['GOOGLE_CALENDAR_PROJECT_ID'] || 'mobilis-ticket'
-    
-    # 環境変数が設定されている場合、認証情報ファイルを生成
+
+    # 同期が無効でも再認証できるよう、環境変数があれば認証情報を生成する
     if client_id.present? && client_secret.present?
       unless File.exist?(credentials_path)
         credentials_data = {
@@ -26,7 +26,7 @@ begin
             redirect_uris: ["http://localhost"]
           }
         }
-        
+
         begin
           File.write(credentials_path, JSON.pretty_generate(credentials_data))
           Rails.logger.info "✅ Google Calendar credentials file created from environment variables"
@@ -44,4 +44,3 @@ rescue => e
   Rails.logger.error "❌ Backtrace: #{e.backtrace.first(5).join("\n")}"
   # エラーが発生してもアプリケーションは起動を続行
 end
-


### PR DESCRIPTION
## What changed

- Generate the Google Calendar credentials file in production whenever the required Heroku config vars exist, even when calendar sync is disabled.
- Remove committed OAuth credential values from the Heroku deployment guide.

## Why

The booking integration must remain disabled while its refresh token is invalid, but the previous initializer also prevented credentials from being generated in that state. The admin page therefore hid the reauthorization button.

## Impact

After deployment, the app can keep `GOOGLE_CALENDAR_SYNC_ENABLED=false` while the administrator completes Google reauthorization. Calendar-based slot filtering can then be enabled only after a successful connection test.

## Validation

Reviewed the production initializer, admin visibility condition, and Google Calendar service credential path together. CI should validate the branch after the PR is opened.

## Security follow-up

The Google OAuth client secret previously appeared in repository documentation. It must be rotated in Google Cloud Console and the Heroku config var updated.