### PR TITLE
Replace deprecated Google OAuth OOB flow

### DIFF
--- a/app/controllers/admin/google_calendar_controller.rb
+++ b/app/controllers/admin/google_calendar_controller.rb
@@ -38,36 +38,63 @@ class Admin::GoogleCalendarController < ApplicationController
   end
 
   def authorize
-    begin
-      auth_url = GoogleCalendarSync.get_authorization_url
-      if auth_url
-        redirect_to auth_url, allow_other_host: true
-      else
-        flash[:alert] = "認証URLの取得に失敗しました。認証情報ファイルが正しく設定されているか確認してください。"
-        redirect_to admin_google_calendar_index_path
-      end
-    rescue => e
-      flash[:alert] = "認証エラー: #{e.message}"
+    state = SecureRandom.hex(32)
+    session[:google_calendar_oauth_state] = state
+    callback_url = callback_admin_google_calendar_index_url
+
+    auth_url = GoogleCalendarSync.get_authorization_url(
+      base_url: callback_url,
+      state: state
+    )
+
+    if auth_url
+      redirect_to auth_url, allow_other_host: true
+    else
+      flash[:alert] = "認証URLの取得に失敗しました。Google CloudのOAuth設定を確認してください。"
       redirect_to admin_google_calendar_index_path
     end
+  rescue => e
+    flash[:alert] = "認証エラー: #{e.message}"
+    redirect_to admin_google_calendar_index_path
   end
 
   def callback
-    code = params[:code]
-    if code.present?
-      begin
-        credentials = GoogleCalendarSync.authorize_with_code(code)
-        if credentials
-          flash[:notice] = "Googleカレンダーとの認証が完了しました"
-        else
-          flash[:alert] = "認証に失敗しました。認証コードが正しいか確認してください。"
-        end
-      rescue => e
-        flash[:alert] = "認証エラー: #{e.message}"
+    if params[:error].present?
+      flash[:alert] = "Google認証がキャンセルされました: #{params[:error]}"
+      redirect_to admin_google_calendar_index_path
+      return
+    end
+
+    expected_state = session.delete(:google_calendar_oauth_state)
+    received_state = params[:state].to_s
+    state_valid = expected_state.present? &&
+                  received_state.bytesize == expected_state.bytesize &&
+                  ActiveSupport::SecurityUtils.secure_compare(received_state, expected_state)
+
+    unless state_valid
+      flash[:alert] = "認証の確認に失敗しました。もう一度認証を開始してください。"
+      redirect_to admin_google_calendar_index_path
+      return
+    end
+
+    if params[:code].present?
+      credentials = GoogleCalendarSync.authorize_with_code(
+        params[:code],
+        base_url: callback_admin_google_calendar_index_url
+      )
+
+      if credentials
+        flash[:notice] = "Googleカレンダーとの認証が完了しました"
+      else
+        flash[:alert] = "認証に失敗しました。Google CloudのOAuth設定を確認してください。"
       end
     else
-      flash[:alert] = "認証コードが取得できませんでした。"
+      flash[:alert] = "Googleから認証コードを取得できませんでした。"
     end
+
+    redirect_to admin_google_calendar_index_path
+  rescue => e
+    flash[:alert] = "認証エラー: #{e.message}"
     redirect_to admin_google_calendar_index_path
   end
 

--- a/app/services/google_calendar_sync.rb
+++ b/app/services/google_calendar_sync.rb
@@ -351,36 +351,33 @@ class GoogleCalendarSync
   end
 
   # 認証URLを取得
-  def self.get_authorization_url
+  def self.get_authorization_url(base_url:, state:)
     return nil unless File.exist?(Rails.root.join('config', 'google_calendar_credentials.json'))
-    
+
     client_id = Google::Auth::ClientId.from_file(Rails.root.join('config', 'google_calendar_credentials.json'))
-    # データベースにトークンが存在する場合はデータベースストアを使用、なければファイルストアを使用（後方互換性）
-    token_store = if GoogleCalendarToken.exists?(user_id: 'default')
-      GoogleAuthStores::DatabaseTokenStore.new
-    else
-      Google::Auth::Stores::FileTokenStore.new(file: Rails.root.join('config', 'google_calendar_token.yaml'))
-    end
+    token_store = GoogleAuthStores::DatabaseTokenStore.new
     authorizer = Google::Auth::UserAuthorizer.new(client_id, Google::Apis::CalendarV3::AUTH_CALENDAR, token_store)
-    
-    authorizer.get_authorization_url(base_url: 'urn:ietf:wg:oauth:2.0:oob')
+
+    authorizer.get_authorization_url(base_url: base_url, state: state)
   rescue => e
     Rails.logger.error "❌ Failed to get authorization URL: #{e.message}"
     nil
   end
 
-  # 認証コードからトークンを取得
-  def self.authorize_with_code(code)
+  # GoogleのWebコールバックで受け取った認証コードからトークンを取得
+  def self.authorize_with_code(code, base_url:)
     return nil unless File.exist?(Rails.root.join('config', 'google_calendar_credentials.json'))
-    
+
     client_id = Google::Auth::ClientId.from_file(Rails.root.join('config', 'google_calendar_credentials.json'))
-    # 認証時は常にデータベースストアを使用（新しいトークンはデータベースに保存）
     token_store = GoogleAuthStores::DatabaseTokenStore.new
     authorizer = Google::Auth::UserAuthorizer.new(client_id, Google::Apis::CalendarV3::AUTH_CALENDAR, token_store)
-    
-    user_id = 'default'
-    credentials = authorizer.get_and_store_credentials_from_code(user_id: user_id, code: code, base_url: 'urn:ietf:wg:oauth:2.0:oob')
-    
+
+    credentials = authorizer.get_and_store_credentials_from_code(
+      user_id: 'default',
+      code: code,
+      base_url: base_url
+    )
+
     Rails.logger.info "✅ Google Calendar authorization completed"
     credentials
   rescue => e

--- a/app/views/admin/google_calendar/index.html.erb
+++ b/app/views/admin/google_calendar/index.html.erb
@@ -137,9 +137,9 @@
           <ol>
             <li>Google Cloud Consoleでプロジェクトを作成</li>
             <li>Calendar APIを有効化</li>
-            <li>OAuth認証情報を作成</li>
-            <li>認証情報ファイルを <code>config/google_calendar_credentials.json</code> に配置</li>
-            <li>下の「認証」ボタンから認証を完了</li>
+            <li>OAuth認証情報（ウェブアプリケーション）を作成</li>
+            <li>HerokuにクライアントID・シークレット・リダイレクトURIを設定</li>
+            <li>下の「認証」ボタンからGoogle認証を完了</li>
           </ol>
           
           <% if @credentials_exist %>
@@ -153,20 +153,12 @@
             <div class="mb-3">
               <%= link_to(@token_exist ? "再認証を開始" : "認証を開始",
                           authorize_admin_google_calendar_index_path,
-                          class: "btn btn-primary",
-                          target: "_blank") %>
+                          class: "btn btn-primary") %>
             </div>
 
-            <div class="mt-3">
-              <p class="mb-2"><strong>認証コードを入力してください：</strong></p>
-              <p class="text-muted small mb-3">
-                Googleの認証画面で認証コードが表示されたら、そのコードをコピーして下のフォームに入力してください。
-              </p>
-              <%= form_with url: callback_admin_google_calendar_index_path, method: :get, local: true, class: "d-flex gap-2" do |f| %>
-                <%= f.text_field :code, class: "form-control", placeholder: "認証コードを貼り付け", required: true %>
-                <%= f.submit "認証を完了", class: "btn btn-success" %>
-              <% end %>
-            </div>
+            <p class="text-muted small mb-0">
+              Googleで認証すると、この管理画面へ自動的に戻ります。
+            </p>
           <% else %>
             <div class="alert alert-warning">
               <i class="fas fa-exclamation-triangle me-2"></i>認証情報ファイルが設定されていません

--- a/config/initializers/google_calendar_credentials.rb
+++ b/config/initializers/google_calendar_credentials.rb
@@ -11,19 +11,20 @@ begin
     client_id = ENV['GOOGLE_CALENDAR_CLIENT_ID']
     client_secret = ENV['GOOGLE_CALENDAR_CLIENT_SECRET']
     project_id = ENV['GOOGLE_CALENDAR_PROJECT_ID'] || 'mobilis-ticket'
+    redirect_uri = ENV['GOOGLE_CALENDAR_REDIRECT_URI']
 
     # 同期が無効でも再認証できるよう、環境変数があれば認証情報を生成する
-    if client_id.present? && client_secret.present?
+    if client_id.present? && client_secret.present? && redirect_uri.present?
       unless File.exist?(credentials_path)
         credentials_data = {
-          installed: {
+          web: {
             client_id: client_id,
             project_id: project_id,
             auth_uri: "https://accounts.google.com/o/oauth2/auth",
             token_uri: "https://oauth2.googleapis.com/token",
             auth_provider_x509_cert_url: "https://www.googleapis.com/oauth2/v1/certs",
             client_secret: client_secret,
-            redirect_uris: ["http://localhost"]
+            redirect_uris: [redirect_uri]
           }
         }
 
@@ -36,7 +37,7 @@ begin
         end
       end
     else
-      Rails.logger.warn "⚠️ Google Calendar credentials environment variables not set"
+      Rails.logger.warn "⚠️ Google Calendar credential or redirect URI environment variables not set"
     end
   end
 rescue => e

--- a/test/services/google_calendar_sync_test.rb
+++ b/test/services/google_calendar_sync_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "ostruct"
+require "minitest/mock"
 
 class GoogleCalendarSyncTest < ActiveSupport::TestCase
   test "FreeBusy request uses DateTime values and an IANA time zone" do

--- a/test/services/google_calendar_sync_test.rb
+++ b/test/services/google_calendar_sync_test.rb
@@ -25,4 +25,60 @@ class GoogleCalendarSyncTest < ActiveSupport::TestCase
     assert_equal "Asia/Tokyo", captured_request.time_zone
     assert_equal "primary", captured_request.items.first.id
   end
+
+  test "authorization URL uses the registered web callback and state" do
+    captured = nil
+    authorizer = Object.new
+    authorizer.define_singleton_method(:get_authorization_url) do |**options|
+      captured = options
+      "https://accounts.google.com/o/oauth2/auth"
+    end
+
+    File.stub(:exist?, true) do
+      Google::Auth::ClientId.stub(:from_file, Object.new) do
+        GoogleAuthStores::DatabaseTokenStore.stub(:new, Object.new) do
+          Google::Auth::UserAuthorizer.stub(:new, authorizer) do
+            url = GoogleCalendarSync.get_authorization_url(
+              base_url: "https://example.com/admin/google_calendar/callback",
+              state: "secure-state"
+            )
+
+            assert_equal "https://accounts.google.com/o/oauth2/auth", url
+          end
+        end
+      end
+    end
+
+    assert_equal "https://example.com/admin/google_calendar/callback", captured[:base_url]
+    assert_equal "secure-state", captured[:state]
+  end
+
+  test "authorization code exchange uses the same web callback" do
+    captured = nil
+    credentials = Object.new
+    authorizer = Object.new
+    authorizer.define_singleton_method(:get_and_store_credentials_from_code) do |**options|
+      captured = options
+      credentials
+    end
+
+    File.stub(:exist?, true) do
+      Google::Auth::ClientId.stub(:from_file, Object.new) do
+        GoogleAuthStores::DatabaseTokenStore.stub(:new, Object.new) do
+          Google::Auth::UserAuthorizer.stub(:new, authorizer) do
+            result = GoogleCalendarSync.authorize_with_code(
+              "authorization-code",
+              base_url: "https://example.com/admin/google_calendar/callback"
+            )
+
+            assert_same credentials, result
+          end
+        end
+      end
+    end
+
+    assert_equal "default", captured[:user_id]
+    assert_equal "authorization-code", captured[:code]
+    assert_equal "https://example.com/admin/google_calendar/callback", captured[:base_url]
+  end
 end


### PR DESCRIPTION
## What changed

- Replace the deprecated out-of-band OAuth code flow with a normal HTTPS callback.
- Add OAuth state validation to protect the admin authorization flow.
- Store the returned token automatically and remove the manual code-entry form.
- Generate Heroku credentials as a web OAuth client using `GOOGLE_CALENDAR_REDIRECT_URI`.
- Add regression tests for authorization URL generation and code exchange.

## Root cause

The app sent `urn:ietf:wg:oauth:2.0:oob` as its redirect URI. Google blocks this deprecated flow in production and returns `Error 400: invalid_request`.

## Required production configuration

Create a Google OAuth client of type **Web application** and register:

`https://mobilis-8008d58dd542.herokuapp.com/admin/google_calendar/callback`

Then update these Heroku config vars with that web client's values:

- `GOOGLE_CALENDAR_CLIENT_ID`
- `GOOGLE_CALENDAR_CLIENT_SECRET`
- `GOOGLE_CALENDAR_REDIRECT_URI`

## Validation

CI will run the service tests, full Rails test suite, lint, and security scans.