### PR TITLE
Add Google OAuth callback route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 Rails.application.routes.draw do
   # ルートページ
   root 'admin/dashboard#index'
+  get 'oauth2callback', to: 'admin/google_calendar#callback'
   
   # 管理者用ルート
   namespace :admin do


### PR DESCRIPTION
Add the top-level `/oauth2callback` endpoint required by the Google Ruby authorization library. Register `https://mobilis-8008d58dd542.herokuapp.com/oauth2callback` in Google Cloud and use the same value for the Heroku redirect URI setting.