### PR TITLE
Keep booking slots visible during brief Google outages

### DIFF
--- a/app/controllers/public/bookings_controller.rb
+++ b/app/controllers/public/bookings_controller.rb
@@ -1,6 +1,8 @@
 # app/controllers/public/bookings_controller.rb の修正版
 
 class Public::BookingsController < ApplicationController
+  GOOGLE_CALENDAR_AVAILABILITY_CACHE_TTL = 10.minutes
+
   # 認証をスキップ（一般ユーザー向けページのため）
   skip_before_action :verify_authenticity_token, only: [:available_times, :week_calendar]
   
@@ -140,6 +142,21 @@ class Public::BookingsController < ApplicationController
       return render :new, status: :unprocessable_entity
     end
     
+    # 表示には短時間のキャッシュを利用できるが、予約確定前は必ず
+    # Google Calendarを直接確認して二重予約を防ぐ。
+    google_calendar_status = google_calendar_booking_status(@reservation)
+    if google_calendar_status == :conflict
+      Rails.logger.error "❌ Google Calendar conflict detected"
+      flash[:alert] = '選択された時間は既に予定が入っています。別の時間をお選びください。'
+      @reservation = Reservation.new
+      return render :new, status: :unprocessable_entity
+    elsif google_calendar_status == :unavailable
+      Rails.logger.error "❌ Booking rejected because Google Calendar could not be checked"
+      flash[:alert] = '現在カレンダーを確認できません。恐れ入りますが、少し時間をおいて再度お試しください。'
+      @reservation = Reservation.new
+      return render :new, status: :service_unavailable
+    end
+
     if @reservation.save
         Rails.logger.info "✅ Reservation created successfully: #{@reservation.id}"
       # LINE通知を送信
@@ -374,14 +391,65 @@ class Public::BookingsController < ApplicationController
   def google_calendar_busy_periods_for(date)
     return [] unless google_calendar_enabled?
 
+    cache_key = google_calendar_cache_key(date)
     @google_calendar_sync ||= GoogleCalendarSync.new
-    @google_calendar_sync.busy_periods(
+    busy_periods = @google_calendar_sync.busy_periods(
       start_time: date.beginning_of_day.in_time_zone,
       end_time: date.end_of_day.in_time_zone
     )
+
+    if busy_periods.nil?
+      cached_periods = google_calendar_cache.read(cache_key)
+      unless cached_periods.nil?
+        Rails.logger.warn "⚠️ Using cached Google Calendar availability for #{date}"
+        return cached_periods
+      end
+
+      return nil
+    end
+
+    google_calendar_cache.write(
+      cache_key,
+      busy_periods,
+      expires_in: GOOGLE_CALENDAR_AVAILABILITY_CACHE_TTL
+    )
+    busy_periods
   rescue => e
     Rails.logger.error "❌ Google Calendar availability check failed for #{date}: #{e.message}"
+    cached_periods = google_calendar_cache.read(google_calendar_cache_key(date))
+    return cached_periods unless cached_periods.nil?
+
     nil
+  end
+
+  def google_calendar_booking_status(reservation)
+    return :available unless google_calendar_enabled?
+
+    interval_minutes = ApplicationSetting.current.reservation_interval_minutes
+    @google_calendar_sync ||= GoogleCalendarSync.new
+    busy_periods = @google_calendar_sync.busy_periods(
+      start_time: reservation.start_time - interval_minutes.minutes,
+      end_time: reservation.end_time + interval_minutes.minutes
+    )
+    return :unavailable if busy_periods.nil?
+
+    google_calendar_slot_available?(
+      reservation.start_time,
+      reservation.end_time,
+      interval_minutes,
+      busy_periods
+    ) ? :available : :conflict
+  rescue => e
+    Rails.logger.error "❌ Final Google Calendar booking check failed: #{e.message}"
+    :unavailable
+  end
+
+  def google_calendar_cache
+    Rails.cache
+  end
+
+  def google_calendar_cache_key(date)
+    "google_calendar/busy_periods/#{date.iso8601}"
   end
 
   def google_calendar_slot_available?(start_time, end_time, interval_minutes, busy_periods)

--- a/app/controllers/public/bookings_controller.rb
+++ b/app/controllers/public/bookings_controller.rb
@@ -425,7 +425,7 @@ class Public::BookingsController < ApplicationController
   def google_calendar_booking_status(reservation)
     return :available unless google_calendar_enabled?
 
-    interval_minutes = ApplicationSetting.current.reservation_interval_minutes
+    interval_minutes = google_calendar_interval_minutes
     @google_calendar_sync ||= GoogleCalendarSync.new
     busy_periods = @google_calendar_sync.busy_periods(
       start_time: reservation.start_time - interval_minutes.minutes,
@@ -442,6 +442,10 @@ class Public::BookingsController < ApplicationController
   rescue => e
     Rails.logger.error "❌ Final Google Calendar booking check failed: #{e.message}"
     :unavailable
+  end
+
+  def google_calendar_interval_minutes
+    ApplicationSetting.current.reservation_interval_minutes
   end
 
   def google_calendar_cache

--- a/test/controllers/public/bookings_controller_test.rb
+++ b/test/controllers/public/bookings_controller_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require "minitest/mock"
 require "ostruct"
 
 class Public::BookingsControllerTest < ActiveSupport::TestCase
@@ -95,9 +94,9 @@ class Public::BookingsControllerTest < ActiveSupport::TestCase
     @controller.instance_variable_set(:@google_calendar_sync, sync)
     @controller.define_singleton_method(:google_calendar_enabled?) { true }
 
-    ApplicationSetting.stub(:current, OpenStruct.new(reservation_interval_minutes: 20)) do
-      assert_equal :unavailable, @controller.send(:google_calendar_booking_status, reservation)
-    end
+    @controller.define_singleton_method(:google_calendar_interval_minutes) { 20 }
+
+    assert_equal :unavailable, @controller.send(:google_calendar_booking_status, reservation)
   end
 
   test "final booking check rejects a live Google conflict" do
@@ -109,8 +108,8 @@ class Public::BookingsControllerTest < ActiveSupport::TestCase
     @controller.instance_variable_set(:@google_calendar_sync, sync)
     @controller.define_singleton_method(:google_calendar_enabled?) { true }
 
-    ApplicationSetting.stub(:current, OpenStruct.new(reservation_interval_minutes: 20)) do
-      assert_equal :conflict, @controller.send(:google_calendar_booking_status, reservation)
-    end
+    @controller.define_singleton_method(:google_calendar_interval_minutes) { 20 }
+
+    assert_equal :conflict, @controller.send(:google_calendar_booking_status, reservation)
   end
 end

--- a/test/controllers/public/bookings_controller_test.rb
+++ b/test/controllers/public/bookings_controller_test.rb
@@ -1,4 +1,6 @@
 require "test_helper"
+require "minitest/mock"
+require "ostruct"
 
 class Public::BookingsControllerTest < ActiveSupport::TestCase
   setup do
@@ -55,5 +57,60 @@ class Public::BookingsControllerTest < ActiveSupport::TestCase
     )
 
     assert available
+  end
+
+  test "recent Google availability is used when a refresh temporarily fails" do
+    date = Date.new(2026, 8, 20)
+    periods = [{ start_time: @start_time, end_time: @end_time }]
+    responses = [periods, nil]
+    sync = Object.new
+    sync.define_singleton_method(:busy_periods) { |**| responses.shift }
+    cache = ActiveSupport::Cache::MemoryStore.new
+
+    @controller.instance_variable_set(:@google_calendar_sync, sync)
+    @controller.define_singleton_method(:google_calendar_enabled?) { true }
+    @controller.define_singleton_method(:google_calendar_cache) { cache }
+
+    assert_equal periods, @controller.send(:google_calendar_busy_periods_for, date)
+    assert_equal periods, @controller.send(:google_calendar_busy_periods_for, date)
+  end
+
+  test "availability fails closed without a recent cache" do
+    date = Date.new(2026, 8, 20)
+    sync = Object.new
+    sync.define_singleton_method(:busy_periods) { |**| nil }
+    cache = ActiveSupport::Cache::MemoryStore.new
+
+    @controller.instance_variable_set(:@google_calendar_sync, sync)
+    @controller.define_singleton_method(:google_calendar_enabled?) { true }
+    @controller.define_singleton_method(:google_calendar_cache) { cache }
+
+    assert_nil @controller.send(:google_calendar_busy_periods_for, date)
+  end
+
+  test "final booking check rejects a booking when Google cannot be reached" do
+    reservation = OpenStruct.new(start_time: @start_time, end_time: @end_time)
+    sync = Object.new
+    sync.define_singleton_method(:busy_periods) { |**| nil }
+    @controller.instance_variable_set(:@google_calendar_sync, sync)
+    @controller.define_singleton_method(:google_calendar_enabled?) { true }
+
+    ApplicationSetting.stub(:current, OpenStruct.new(reservation_interval_minutes: 20)) do
+      assert_equal :unavailable, @controller.send(:google_calendar_booking_status, reservation)
+    end
+  end
+
+  test "final booking check rejects a live Google conflict" do
+    reservation = OpenStruct.new(start_time: @start_time, end_time: @end_time)
+    sync = Object.new
+    sync.define_singleton_method(:busy_periods) do |**|
+      [{ start_time: @start_time + 30.minutes, end_time: @end_time + 30.minutes }]
+    end
+    @controller.instance_variable_set(:@google_calendar_sync, sync)
+    @controller.define_singleton_method(:google_calendar_enabled?) { true }
+
+    ApplicationSetting.stub(:current, OpenStruct.new(reservation_interval_minutes: 20)) do
+      assert_equal :conflict, @controller.send(:google_calendar_booking_status, reservation)
+    end
   end
 end

--- a/test/controllers/public/bookings_controller_test.rb
+++ b/test/controllers/public/bookings_controller_test.rb
@@ -101,9 +101,11 @@ class Public::BookingsControllerTest < ActiveSupport::TestCase
 
   test "final booking check rejects a live Google conflict" do
     reservation = OpenStruct.new(start_time: @start_time, end_time: @end_time)
+    busy_start = @start_time + 30.minutes
+    busy_end = @end_time + 30.minutes
     sync = Object.new
     sync.define_singleton_method(:busy_periods) do |**|
-      [{ start_time: @start_time + 30.minutes, end_time: @end_time + 30.minutes }]
+      [{ start_time: busy_start, end_time: busy_end }]
     end
     @controller.instance_variable_set(:@google_calendar_sync, sync)
     @controller.define_singleton_method(:google_calendar_enabled?) { true }


### PR DESCRIPTION
## What changed

- Cache each day's last successful Google Calendar busy-period response for 10 minutes.
- Use that recent result when a temporary Google API error occurs, instead of immediately hiding every slot.
- Recheck Google Calendar live immediately before saving a booking.
- Reject the booking safely if the final live check fails or finds a conflict.
- Add regression tests for cached fallback, fail-closed behavior without a cache, and final booking validation.

## Safety model

The cached result affects display only. Booking creation never trusts stale calendar data, preventing double bookings during an outage.

## Validation

CI will run tests, lint, and security scans.