### PR TITLE
Notify admins about Google Calendar outages

### DIFF
--- a/app/controllers/admin/google_calendar_controller.rb
+++ b/app/controllers/admin/google_calendar_controller.rb
@@ -13,6 +13,7 @@ class Admin::GoogleCalendarController < ApplicationController
       @token_exist = GoogleCalendarToken.exists?(user_id: 'default') || File.exist?(Rails.root.join('config', 'google_calendar_token.yaml'))
       # アクティブなWebhookチャンネルを取得
       @active_channel = GoogleCalendarChannel.active.first
+      @calendar_health = GoogleCalendarHealth.current
       
       # 同期統計を取得
       if @sync_enabled && @token_exist
@@ -32,6 +33,7 @@ class Admin::GoogleCalendarController < ApplicationController
       @credentials_exist = false
       @token_exist = false
       @active_channel = nil
+      @calendar_health = nil
       @sync_stats = nil
       flash[:alert] = "設定の読み込み中にエラーが発生しました: #{e.message}"
     end

--- a/app/mailers/google_calendar_health_mailer.rb
+++ b/app/mailers/google_calendar_health_mailer.rb
@@ -1,0 +1,38 @@
+class GoogleCalendarHealthMailer < ApplicationMailer
+  def failure(health)
+    @health = health
+
+    mail(
+      to: ENV.fetch("ADMIN_EMAIL", "admin@mobilis-stretch.com"),
+      subject: "【Mobilis】Googleカレンダー接続エラー"
+    ) do |format|
+      format.text do
+        render plain: <<~TEXT
+          Googleカレンダーの空き状況を取得できませんでした。
+
+          発生日時: #{@health.last_failure_at&.in_time_zone&.strftime("%Y年%m月%d日 %H:%M")}
+          エラー: #{@health.last_error}
+
+          Mobilis管理画面で接続テストを行い、必要に応じて再認証してください。
+        TEXT
+      end
+    end
+  end
+
+  def recovered(health)
+    @health = health
+
+    mail(
+      to: ENV.fetch("ADMIN_EMAIL", "admin@mobilis-stretch.com"),
+      subject: "【Mobilis】Googleカレンダー接続が復旧しました"
+    ) do |format|
+      format.text do
+        render plain: <<~TEXT
+          Googleカレンダーとの接続が復旧しました。
+
+          復旧確認日時: #{@health.last_success_at&.in_time_zone&.strftime("%Y年%m月%d日 %H:%M")}
+        TEXT
+      end
+    end
+  end
+end

--- a/app/models/google_calendar_health.rb
+++ b/app/models/google_calendar_health.rb
@@ -1,0 +1,51 @@
+class GoogleCalendarHealth < ApplicationRecord
+  NOTIFICATION_COOLDOWN = 1.hour
+
+  validates :key, presence: true, uniqueness: true
+  validates :status, inclusion: { in: %w[unknown healthy failing] }
+
+  def self.current
+    find_or_create_by!(key: "default")
+  end
+
+  def self.record_success!
+    health = current
+    recovered = health.status == "failing"
+
+    health.update!(
+      status: "healthy",
+      last_success_at: Time.current,
+      last_error: nil
+    )
+
+    GoogleCalendarHealthMailer.recovered(health).deliver_later if recovered
+    health
+  rescue => e
+    Rails.logger.error "❌ Failed to record Google Calendar recovery: #{e.message}"
+    nil
+  end
+
+  def self.record_failure!(message)
+    health = current
+    notify = false
+
+    health.with_lock do
+      notify = health.last_failure_notified_at.nil? ||
+               health.last_failure_notified_at < NOTIFICATION_COOLDOWN.ago
+
+      attributes = {
+        status: "failing",
+        last_failure_at: Time.current,
+        last_error: message.to_s.truncate(1000)
+      }
+      attributes[:last_failure_notified_at] = Time.current if notify
+      health.update!(attributes)
+    end
+
+    GoogleCalendarHealthMailer.failure(health).deliver_later if notify
+    health
+  rescue => e
+    Rails.logger.error "❌ Failed to record Google Calendar failure: #{e.message}"
+    nil
+  end
+end

--- a/app/services/google_calendar_sync.rb
+++ b/app/services/google_calendar_sync.rb
@@ -125,7 +125,10 @@ class GoogleCalendarSync
   # nil means Google Calendar could not be checked. An empty array means the
   # calendar was checked successfully and there are no busy periods.
   def busy_periods(start_time:, end_time:)
-    return nil unless authorized?
+    unless authorized?
+      GoogleCalendarHealth.record_failure!("Google Calendar authorization is unavailable")
+      return nil
+    end
 
     request = Google::Apis::CalendarV3::FreeBusyRequest.new(
       time_min: start_time.to_datetime,
@@ -137,14 +140,18 @@ class GoogleCalendarSync
     response = @service.query_freebusy(request)
     calendars = response.calendars || {}
 
-    calendars.values.flat_map { |calendar| calendar.busy || [] }.map do |period|
+    periods = calendars.values.flat_map { |calendar| calendar.busy || [] }.map do |period|
       {
         start_time: Time.zone.parse(period.start.to_s),
         end_time: Time.zone.parse(period.end.to_s)
       }
     end
+
+    GoogleCalendarHealth.record_success!
+    periods
   rescue => e
     Rails.logger.error "❌ Failed to fetch Google Calendar free/busy data: #{e.message}"
+    GoogleCalendarHealth.record_failure!(e.message)
     nil
   end
 

--- a/app/views/admin/google_calendar/index.html.erb
+++ b/app/views/admin/google_calendar/index.html.erb
@@ -66,6 +66,28 @@
             </div>
             <div class="col-md-6">
               <p>
+                <strong>Google接続状態:</strong>
+                <% if @calendar_health&.status == "healthy" %>
+                  <span class="badge bg-success">正常</span>
+                <% elsif @calendar_health&.status == "failing" %>
+                  <span class="badge bg-danger">接続エラー</span>
+                <% else %>
+                  <span class="badge bg-secondary">未確認</span>
+                <% end %>
+                <% if @calendar_health&.last_success_at %>
+                  <small class="text-muted d-block mt-1">
+                    最終成功: <%= @calendar_health.last_success_at.in_time_zone.strftime('%Y年%m月%d日 %H:%M') %>
+                  </small>
+                <% end %>
+                <% if @calendar_health&.status == "failing" && @calendar_health.last_error.present? %>
+                  <small class="text-danger d-block mt-1">
+                    <%= truncate(@calendar_health.last_error, length: 120) %>
+                  </small>
+                <% end %>
+              </p>
+            </div>
+            <div class="col-md-6">
+              <p>
                 <strong>リアルタイム同期（Webhook）:</strong>
                 <% if @active_channel %>
                   <span class="badge bg-success">有効</span>

--- a/db/migrate/20260818000000_create_google_calendar_healths.rb
+++ b/db/migrate/20260818000000_create_google_calendar_healths.rb
@@ -1,0 +1,16 @@
+class CreateGoogleCalendarHealths < ActiveRecord::Migration[7.2]
+  def change
+    create_table :google_calendar_healths do |t|
+      t.string :key, null: false, default: "default"
+      t.string :status, null: false, default: "unknown"
+      t.datetime :last_success_at
+      t.datetime :last_failure_at
+      t.datetime :last_failure_notified_at
+      t.text :last_error
+
+      t.timestamps
+    end
+
+    add_index :google_calendar_healths, :key, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_24_000001) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_18_000000) do
   create_table "admin_users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -49,6 +49,18 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_24_000001) do
     t.datetime "updated_at", null: false
     t.index ["channel_id"], name: "index_google_calendar_channels_on_channel_id", unique: true
     t.index ["expiration"], name: "index_google_calendar_channels_on_expiration"
+  end
+
+  create_table "google_calendar_healths", force: :cascade do |t|
+    t.string "key", default: "default", null: false
+    t.string "status", default: "unknown", null: false
+    t.datetime "last_success_at"
+    t.datetime "last_failure_at"
+    t.datetime "last_failure_notified_at"
+    t.text "last_error"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_google_calendar_healths_on_key", unique: true
   end
 
   create_table "google_calendar_tokens", force: :cascade do |t|

--- a/test/models/google_calendar_health_test.rb
+++ b/test/models/google_calendar_health_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class GoogleCalendarHealthTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+  include ActionMailer::TestHelper
+
+  setup do
+    GoogleCalendarHealth.delete_all
+    clear_enqueued_jobs
+  end
+
+  test "failure notification is limited to once per hour" do
+    assert_enqueued_emails 1 do
+      GoogleCalendarHealth.record_failure!("invalid_grant")
+      GoogleCalendarHealth.record_failure!("invalid_grant")
+    end
+
+    health = GoogleCalendarHealth.current
+    assert_equal "failing", health.status
+    assert_equal "invalid_grant", health.last_error
+    assert_not_nil health.last_failure_at
+    assert_not_nil health.last_failure_notified_at
+  end
+
+  test "recovery sends one notification and records the last success" do
+    GoogleCalendarHealth.record_failure!("temporary failure")
+    clear_enqueued_jobs
+
+    assert_enqueued_emails 1 do
+      GoogleCalendarHealth.record_success!
+      GoogleCalendarHealth.record_success!
+    end
+
+    health = GoogleCalendarHealth.current
+    assert_equal "healthy", health.status
+    assert_nil health.last_error
+    assert_not_nil health.last_success_at
+  end
+end


### PR DESCRIPTION
## What changed

- Persist Google Calendar connection health in the database.
- Record the latest success, failure, and error message from FreeBusy checks.
- Email `ADMIN_EMAIL` when the connection fails, limited to once per hour.
- Email again when the connection recovers.
- Show current status and the last successful check in the admin Google Calendar screen.
- Add tests for notification throttling and recovery transitions.

## Operational impact

A transient error no longer produces repeated email noise, but a continuing outage can remind the administrator once per hour. Normal availability behavior remains unchanged.

## Deployment

Run the included database migration during the Heroku release.

## Validation

CI will run tests, lint, and security scans.