### PR TITLE
Save booking email for returning customers

### DIFF
--- a/app/controllers/public/bookings_controller.rb
+++ b/app/controllers/public/bookings_controller.rb
@@ -591,7 +591,13 @@ class Public::BookingsController < ApplicationController
     phone = booking_params[:phone_number]
     
     user = User.find_by(phone_number: phone)
-    return user if user
+    if user
+      # Repeated bookings must keep the customer profile in sync with the
+      # values submitted in the current booking form.
+      user.assign_attributes(user_attributes.compact_blank)
+      user.save
+      return user
+    end
 
     # 新規ユーザー作成
     User.create(user_attributes)

--- a/test/controllers/public/bookings_controller_test.rb
+++ b/test/controllers/public/bookings_controller_test.rb
@@ -8,6 +8,27 @@ class Public::BookingsControllerTest < ActiveSupport::TestCase
     @end_time = Time.zone.parse("2026-08-20 11:00")
   end
 
+  test "existing customer is updated from the current booking form" do
+    user = users(:one)
+    user.update!(phone_number: "09012345678", email: nil, address: nil)
+
+    submitted = ActionController::Parameters.new(
+      name: "Updated Name",
+      phone_number: "09012345678",
+      email: "updated@example.com",
+      address: "Updated Address"
+    ).permit!
+
+    @controller.define_singleton_method(:booking_params) { submitted }
+
+    result = @controller.send(:find_or_create_user)
+
+    assert_equal user.id, result.id
+    assert_equal "updated@example.com", result.reload.email
+    assert_equal "Updated Name", result.name
+    assert_equal "Updated Address", result.address
+  end
+
   test "Google busy period blocks an overlapping booking slot" do
     busy_periods = [
       {


### PR DESCRIPTION
## What changed
- Update an existing customer from the latest public booking form values
- Preserve existing values when a submitted optional field is blank
- Add a regression test for returning customers whose saved email was blank

## Root cause
Customers are matched by phone number. When an existing customer was found, the controller returned it immediately and discarded the email entered in the new booking form. The reservation mailer therefore received a blank recipient.

## Impact
New bookings from returning customers save the submitted email address before the reservation is created, allowing confirmation and cancellation emails to be delivered.

## Validation
GitHub Actions will run the existing test, lint, and security suites.