### PR TITLE
Distinguish tentative bookings from confirmed reservations

### DIFF
--- a/app/mailers/reservation_mailer.rb
+++ b/app/mailers/reservation_mailer.rb
@@ -7,6 +7,7 @@ class ReservationMailer < ApplicationMailer
     @reservation = reservation
     @user = reservation.user
     @salon_name = "Mobilis Stretch"
+    @tentative = reservation.tentative?
     
     # ユーザーの言語設定を判定（デフォルトは日本語）
     user_language = detect_user_language(@user)
@@ -14,9 +15,11 @@ class ReservationMailer < ApplicationMailer
     # 件名を言語に応じて設定
     subject = case user_language
     when :en
-      "[#{@salon_name}] Reservation Confirmation - #{@reservation.start_time.strftime('%m/%d %H:%M')}"
+      status_text = @tentative ? "Booking Request Received" : "Reservation Confirmed"
+      "[#{@salon_name}] #{status_text} - #{@reservation.start_time.strftime('%m/%d %H:%M')}"
     else
-      "【#{@salon_name}】ご予約確認 - #{@reservation.start_time.strftime('%m/%d %H:%M')}"
+      status_text = @tentative ? "仮予約を受け付けました" : "ご予約確定"
+      "【#{@salon_name}】#{status_text} - #{@reservation.start_time.strftime('%m/%d %H:%M')}"
     end
     
     mail(

--- a/app/views/reservation_mailer/confirmation.en.html.erb
+++ b/app/views/reservation_mailer/confirmation.en.html.erb
@@ -3,7 +3,7 @@
 <html>
 <head>
   <meta charset="UTF-8">
-  <title>Reservation Confirmation</title>
+  <title><%= @tentative ? "Booking Request Received" : "Reservation Confirmed" %></title>
   <style>
     body { 
       font-family: Arial, sans-serif; 
@@ -46,14 +46,19 @@
 <body>
   <div class="header">
     <h1><%= @salon_name %></h1>
-    <h2>✅ Reservation Confirmation</h2>
+    <h2><%= @tentative ? "🕒 Booking Request Received" : "✅ Reservation Confirmed" %></h2>
   </div>
   
   <div class="content">
     <p>Dear <strong><%= @user.name %></strong>,</p>
     
-    <p>Thank you for choosing our services.<br>
-    We have received your reservation with the following details:</p>
+    <% if @tentative %>
+      <p>We have received your booking request with the details below.<br>
+      Your appointment is not confirmed yet. We will send another email after reviewing the request.</p>
+    <% else %>
+      <p>Thank you for choosing our services.<br>
+      Your reservation has been confirmed with the following details:</p>
+    <% end %>
     
     <div class="reservation-details">
       <h3>📅 Reservation Details</h3>
@@ -79,8 +84,13 @@
       </table>
     </div>
     
-    <p>If you have any questions, please don't hesitate to contact us.<br>
-    We look forward to seeing you on the day of your appointment.</p>
+    <% if @tentative %>
+      <p>Please wait for your confirmation email.<br>
+      If you have any questions, please don't hesitate to contact us.</p>
+    <% else %>
+      <p>If you have any questions, please don't hesitate to contact us.<br>
+      We look forward to seeing you on the day of your appointment.</p>
+    <% end %>
   </div>
   
   <div class="footer">

--- a/app/views/reservation_mailer/confirmation.html.erb
+++ b/app/views/reservation_mailer/confirmation.html.erb
@@ -3,7 +3,7 @@
 <html>
 <head>
   <meta charset="UTF-8">
-  <title>予約確認</title>
+  <title><%= @tentative ? "仮予約受付" : "予約確定" %></title>
   <style>
     body { 
       font-family: Arial, sans-serif; 
@@ -53,14 +53,19 @@
 <body>
   <div class="header">
     <h1><%= @salon_name %></h1>
-    <h2>✅ ご予約確認</h2>
+    <h2><%= @tentative ? "🕒 仮予約を受け付けました" : "✅ ご予約が確定しました" %></h2>
   </div>
   
   <div class="content">
     <p><strong><%= @user.name %></strong> 様</p>
     
-    <p>いつもご利用いただきありがとうございます。<br>
-    以下の内容でご予約を承りました。</p>
+    <% if @tentative %>
+      <p>ご予約リクエストを受け付けました。<br>
+      現在はまだ予約確定前です。内容を確認後、改めて予約確定メールをお送りします。</p>
+    <% else %>
+      <p>いつもご利用いただきありがとうございます。<br>
+      以下の内容でご予約が確定しました。</p>
+    <% end %>
     
     <div class="reservation-details">
       <h3>📅 予約詳細</h3>
@@ -88,8 +93,13 @@
     
 
     
-    <p>ご不明な点がございましたら、お気軽にお問い合わせください。<br>
-    当日お会いできることを楽しみにしております。</p>
+    <% if @tentative %>
+      <p>確定のご連絡まで、しばらくお待ちください。<br>
+      ご不明な点がございましたら、お気軽にお問い合わせください。</p>
+    <% else %>
+      <p>ご不明な点がございましたら、お気軽にお問い合わせください。<br>
+      当日お会いできることを楽しみにしております。</p>
+    <% end %>
   </div>
   
   <div class="footer">

--- a/test/mailers/reservation_mailer_test.rb
+++ b/test/mailers/reservation_mailer_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class ReservationMailerTest < ActionMailer::TestCase
+  setup do
+    @user = User.new(name: "テストユーザー", email: "customer@example.jp")
+    @attributes = {
+      user: @user,
+      start_time: Time.zone.parse("2026-08-20 10:00"),
+      end_time: Time.zone.parse("2026-08-20 11:00"),
+      course: "60分"
+    }
+  end
+
+  test "tentative reservation is described as a booking request" do
+    reservation = Reservation.new(**@attributes, status: :tentative)
+
+    mail = ReservationMailer.confirmation(reservation)
+
+    assert_includes mail.subject, "仮予約を受け付けました"
+    assert_includes mail.html_part.body.decoded, "現在はまだ予約確定前です"
+  end
+
+  test "confirmed reservation is described as confirmed" do
+    reservation = Reservation.new(**@attributes, status: :confirmed)
+
+    mail = ReservationMailer.confirmation(reservation)
+
+    assert_includes mail.subject, "ご予約確定"
+    assert_includes mail.html_part.body.decoded, "ご予約が確定しました"
+  end
+end

--- a/test/mailers/reservation_mailer_test.rb
+++ b/test/mailers/reservation_mailer_test.rb
@@ -17,7 +17,7 @@ class ReservationMailerTest < ActionMailer::TestCase
     mail = ReservationMailer.confirmation(reservation)
 
     assert_includes mail.subject, "仮予約を受け付けました"
-    assert_includes mail.html_part.body.decoded, "現在はまだ予約確定前です"
+    assert_includes mail.body.decoded, "現在はまだ予約確定前です"
   end
 
   test "confirmed reservation is described as confirmed" do
@@ -26,6 +26,6 @@ class ReservationMailerTest < ActionMailer::TestCase
     mail = ReservationMailer.confirmation(reservation)
 
     assert_includes mail.subject, "ご予約確定"
-    assert_includes mail.html_part.body.decoded, "ご予約が確定しました"
+    assert_includes mail.body.decoded, "ご予約が確定しました"
   end
 end


### PR DESCRIPTION
## What changed
- Label the first email as a booking request when the reservation is tentative
- Clearly state that a tentative booking is not confirmed yet
- Keep the confirmation wording for reservations approved by an administrator
- Apply equivalent wording in Japanese and English
- Add mailer regression tests for both statuses

## Root cause
The same confirmation template and subject were used both immediately after a tentative booking and after the status changed to confirmed.

## Customer impact
Customers now receive an unambiguous two-step flow: booking request received, then reservation confirmed.

## Validation
GitHub Actions will run the test, lint, and security suites.