### PR TITLE
Deliver new booking notifications to admins

### DIFF
--- a/app/controllers/public/bookings_controller.rb
+++ b/app/controllers/public/bookings_controller.rb
@@ -634,7 +634,7 @@ class Public::BookingsController < ApplicationController
   end
 
   def notify_admin(reservation)
-    AdminNotificationJob.perform_later(reservation)
+    AdminNotificationJob.perform_now(reservation)
   rescue => e
     Rails.logger.error "管理者通知エラー: #{e.message}"
   end

--- a/app/jobs/admin_notification_job.rb
+++ b/app/jobs/admin_notification_job.rb
@@ -1,31 +1,18 @@
-# app/jobs/admin_notification_job.rb
 class AdminNotificationJob < ApplicationJob
   def perform(reservation)
-    # 管理者へのSlack通知
-    send_slack_notification(reservation) if Rails.env.production?
-    
-    # 管理者へのメール通知
     AdminMailer.new_booking_request(reservation).deliver_now
-    
+    send_line_notification(reservation)
+
     Rails.logger.info "管理者通知送信完了: 予約ID #{reservation.id}"
   end
 
   private
 
-  def send_slack_notification(reservation)
-    # Slack webhook実装（必要に応じて）
-  end
-end
+  def send_line_notification(reservation)
+    return unless ENV["ADMIN_LINE_USER_ID"].present?
 
-# app/mailers/admin_mailer.rb
-class AdminMailer < ApplicationMailer
-  def new_booking_request(reservation)
-    @reservation = reservation
-    @user = reservation.user
-    
-    mail(
-      to: ENV.fetch('ADMIN_EMAIL', 'admin@mobilis-stretch.com'),
-      subject: "【新規予約】#{@user.name}様からの予約リクエスト"
-    )
+    LineBookingNotifier.send_admin_notification(reservation)
+  rescue => e
+    Rails.logger.error "管理者LINE通知エラー: #{e.message}"
   end
 end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,0 +1,31 @@
+class AdminMailer < ApplicationMailer
+  def new_booking_request(reservation)
+    @reservation = reservation
+    @user = reservation.user
+
+    mail(
+      to: ENV.fetch("ADMIN_EMAIL", "admin@mobilis-stretch.com"),
+      subject: "【新規仮予約】#{@user.name}様からの予約リクエスト"
+    ) do |format|
+      format.text { render plain: message_body }
+    end
+  end
+
+  private
+
+  def message_body
+    <<~TEXT
+      新しい仮予約が入りました。
+
+      お客様名: #{@user.name}
+      予約日時: #{@reservation.start_time.in_time_zone.strftime("%Y年%m月%d日 %H:%M")}〜#{@reservation.end_time.in_time_zone.strftime("%H:%M")}
+      コース: #{@reservation.course}
+      メール: #{@user.email.presence || "未登録"}
+      電話番号: #{@user.phone_number.presence || "未登録"}
+      住所: #{@user.address.presence || "未登録"}
+      備考: #{@reservation.note.presence || "なし"}
+
+      Mobilis Ticketの管理画面で予約内容を確認し、確定してください。
+    TEXT
+  end
+end

--- a/test/mailers/admin_mailer_test.rb
+++ b/test/mailers/admin_mailer_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class AdminMailerTest < ActionMailer::TestCase
+  test "new booking request includes customer and reservation details" do
+    user = User.new(
+      name: "山田太郎",
+      email: "customer@example.com",
+      phone_number: "09012345678",
+      address: "東京都港区"
+    )
+    reservation = Reservation.new(
+      user: user,
+      status: :tentative,
+      start_time: Time.zone.parse("2026-08-20 10:00"),
+      end_time: Time.zone.parse("2026-08-20 11:00"),
+      course: "60分",
+      note: "テスト予約"
+    )
+
+    mail = AdminMailer.new_booking_request(reservation)
+
+    assert_equal [ENV.fetch("ADMIN_EMAIL", "admin@mobilis-stretch.com")], mail.to
+    assert_includes mail.subject, "新規仮予約"
+    assert_includes mail.body.decoded, "山田太郎"
+    assert_includes mail.body.decoded, "09012345678"
+    assert_includes mail.body.decoded, "管理画面で予約内容を確認"
+  end
+end


### PR DESCRIPTION
## What changed
- Run the admin notification immediately instead of queueing it without a worker
- Move `AdminMailer` into its conventional mailer file
- Add a complete plain-text admin email containing customer and reservation details
- Send the optional admin LINE notification when `ADMIN_LINE_USER_ID` is configured
- Add a mailer regression test

## Root cause
`AdminNotificationJob.perform_later` queued work, but the Heroku app has no persistent Active Job worker. The embedded admin mailer also had no renderable email body template.

## Admin impact
Every new public booking now sends an immediate email to `ADMIN_EMAIL`. LINE is also sent when the admin LINE user ID is configured.

## Validation
GitHub Actions will run the test, lint, and security suites.